### PR TITLE
Place package metadata directly in .el files

### DIFF
--- a/connection-pkg.el
+++ b/connection-pkg.el
@@ -1,3 +1,0 @@
-(define-package "connection"
-  "1.10"
-  "TCP-based client connetion")

--- a/connection.el
+++ b/connection.el
@@ -1,7 +1,8 @@
-;;; connection.el -- handling a tcp based connection
+;;; connection.el --- TCP-based client connection
 
 ;; Author: Torsten Hilbrich <torsten.hilbrich@gmx.net>
 ;; Keywords: network
+;; Version: 1.10
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -18,10 +19,14 @@
 ;; the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;; Boston, MA 02111-1307, USA.
 
+;;; Commentary:
+
 ;; connection allows to handle TCP-based connections in client mode
 ;; where text-based information are exchanged. There is special
 ;; support for handling CR LF (and the usual CR LF . CR LF
 ;; terminater).
+
+;;; Code:
 
 (eval-when-compile
   (require 'cl))
@@ -151,3 +156,4 @@ nil: argument is no connection object
   (connection-read connection "\015?\012[.]\015?\012"))
 
 (provide 'connection)
+;;; connection.el ends here

--- a/dictionary-pkg.el
+++ b/dictionary-pkg.el
@@ -1,5 +1,0 @@
-(define-package "dictionary"
-  "1.10"
-  "client for rfc2229 dictionary servers"
-  '((connection "1.10")
-    (link "1.10")))

--- a/dictionary.el
+++ b/dictionary.el
@@ -1,7 +1,9 @@
-;; dictionary.el -- an interface to RFC 2229 dictionary server
+;;; dictionary.el --- Client for rfc2229 dictionary servers
 
 ;; Author: Torsten Hilbrich <torsten.hilbrich@gmx.net>
 ;; Keywords: interface, dictionary
+;; Version: 1.10
+;; Package-Requires: ((connection "1.10") (link "1.10"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -18,6 +20,8 @@
 ;; the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;; Boston, MA 02111-1307, USA.
 
+;;; Commentary:
+
 ;; dictionary allows you to interact with dictionary servers. Use M-x
 ;; customize-group dictioanry to modify all user settings.
 ;;
@@ -27,6 +31,8 @@
 ;;
 ;; You can find more information in the README file of the gibhub
 ;; repository https://github.com/myrkr/dictionary-el
+
+;;; Code:
 
 (eval-when-compile
   (require 'cl))
@@ -1337,3 +1343,4 @@ It presents the word at point as default input and allows editing it."
 
 (provide 'dictionary)
 
+;;; dictionary.el ends here

--- a/link-pkg.el
+++ b/link-pkg.el
@@ -1,4 +1,0 @@
-(define-package "link"
-  "1.10"
-  "hypertext links in text buffers")
-

--- a/link.el
+++ b/link.el
@@ -1,7 +1,8 @@
-;;; link.el -- putting clickable links into the buffer
+;;; link.el --- Hypertext links in text buffers
 
 ;; Author: Torsten Hilbrich <torsten.hilbrich@gmx.net>
 ;; Keywords: interface, hypermedia
+;; Version: 1.10
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -18,7 +19,7 @@
 ;; the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;; Boston, MA 02111-1307, USA.
 
-;; Commentary:
+;;; Commentary:
 
 ;; This file contains functions for using links in buffers.  A link is
 ;; a part of the buffer marked with a special face, beeing
@@ -33,6 +34,8 @@
 ;; link-create-link       - insert a new link for the text in the given range
 ;; link-initialize-keymap - install the keybinding for selecting links
 
+;;; Code:
+
 (eval-when-compile
   (require 'cl))
 
@@ -41,11 +44,11 @@
 The `face' is used for displaying, the `data' are stored together with the
 link.  Upon clicking the `function' is called with `data' as argument."
   (let ((properties `(face ,face
-	              mouse-face highlight
-		      link t
-		      link-data ,data
-		      help-echo ,help
-		      link-function ,function)))
+                      mouse-face highlight
+                      link t
+                      link-data ,data
+                      help-echo ,help
+                      link-function ,function)))
     (remove-text-properties start end properties)
     (add-text-properties start end properties)))
 
@@ -62,10 +65,10 @@ link.  Upon clicking the `function' is called with `data' as argument."
   (interactive)
 
   (let* ((properties (text-properties-at (point)))
-	 (function (plist-get properties 'link-function))
-	 (data (plist-get properties 'link-data)))
+         (function (plist-get properties 'link-function))
+         (data (plist-get properties 'link-data)))
     (if function
-	(funcall function data all))))
+        (funcall function data all))))
 
 (defun link-selected-all ()
   "Called for meta clicking the link"
@@ -89,25 +92,25 @@ link.  Upon clicking the `function' is called with `data' as argument."
 (defun link-next-link ()
   "Return the position of the next link or nil if there is none"
   (let* ((pos (point))
-	 (pos (next-single-property-change pos 'link)))
+         (pos (next-single-property-change pos 'link)))
     (if pos
-	(if (text-property-any pos (min (1+ pos) (point-max)) 'link t)
-	    pos
-	  (next-single-property-change pos 'link))
+        (if (text-property-any pos (min (1+ pos) (point-max)) 'link t)
+            pos
+          (next-single-property-change pos 'link))
       nil)))
-      
+
 
 (defun link-prev-link ()
   "Return the position of the previous link or nil if there is none"
   (let* ((pos (point))
-	 (pos (previous-single-property-change pos 'link)))
+         (pos (previous-single-property-change pos 'link)))
     (if pos
-	(if (text-property-any pos (1+ pos) 'link t)
-	    pos
-	  (let ((val (previous-single-property-change pos 'link)))
-	    (if val
-		val
-	      (text-property-any (point-min) (1+ (point-min)) 'link t))))
+        (if (text-property-any pos (1+ pos) 'link t)
+            pos
+          (let ((val (previous-single-property-change pos 'link)))
+            (if val
+                val
+              (text-property-any (point-min) (1+ (point-min)) 'link t))))
       nil)))
 
 (defun link-initialize-keymap (keymap)
@@ -115,11 +118,12 @@ link.  Upon clicking the `function' is called with `data' as argument."
 
   (if (and (boundp 'running-xemacs) running-xemacs)
       (progn
-	(define-key keymap [button2] 'link-mouse-click)
-	(define-key keymap [(meta button2)] 'link-mouse-click-all))
+        (define-key keymap [button2] 'link-mouse-click)
+        (define-key keymap [(meta button2)] 'link-mouse-click-all))
     (define-key keymap [mouse-2] 'link-mouse-click)
     (define-key keymap [M-mouse-2] 'link-mouse-click-all))
     (define-key keymap "\r" 'link-selected)
     (define-key keymap "\M-\r" 'link-selected-all))
 
 (provide 'link)
+;;; link.el ends here


### PR DESCRIPTION
In the case of single-file packages like this, a -pkg.el is unnecessary.

This commit therefore removes the -pkg.el files and puts the info
directly in the .el files. It also, therefore, adjusts the formatting of
those files slightly in order to be readable by `package-buffer-info`.

(In relation to https://github.com/milkypostman/melpa/pull/864)
