### PR TITLE
Use thing-at-point for proper word recognition

### DIFF
--- a/dictionary.el
+++ b/dictionary.el
@@ -41,6 +41,7 @@
 (require 'custom)
 (require 'connection)
 (require 'link)
+(require 'thingatpt)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Stuff for customizing.
@@ -1102,7 +1103,7 @@ It presents the word at point as default input and allows editing it."
 (defun dictionary-lookup-definition ()
   "Unconditionally lookup the word at point."
   (interactive)
-  (dictionary-new-search (cons (current-word) dictionary-default-dictionary)))
+  (dictionary-new-search (cons (thing-at-point 'word t) dictionary-default-dictionary)))
 
 (defun dictionary-previous ()
   "Go to the previous location in the current buffer"
@@ -1148,7 +1149,7 @@ It presents the word at point as default input and allows editing it."
   (let ((word (save-window-excursion
 		(save-excursion
 		  (mouse-set-point event)
-		  (current-word)))))
+		  (thing-at-point 'word t)))))
     (selected-window)
     (dictionary-popup-matching-words word)))
 
@@ -1158,7 +1159,7 @@ It presents the word at point as default input and allows editing it."
   (interactive)
   (unless (functionp 'popup-menu)
     (error "Sorry, popup menus are not available in this emacs version"))
-  (dictionary-do-matching (or word (current-word))
+  (dictionary-do-matching (or word (thing-at-point 'word t))
 			  dictionary-default-dictionary
 			  dictionary-default-popup-strategy
 			  'dictionary-process-popup-replies))
@@ -1239,7 +1240,7 @@ It presents the word at point as default input and allows editing it."
       (let ((word (save-window-excursion
 		    (save-excursion
 		      (goto-char dictionary-balloon-help-position)
-		      (current-word)))))
+		      (thing-at-point 'word t)))))
 	(let ((definition
 		(dictionary-definition word dictionary-tooltip-dictionary)))
 	  (if definition
@@ -1300,7 +1301,7 @@ It presents the word at point as default input and allows editing it."
       (let ((word (save-window-excursion
  		    (save-excursion
  		      (mouse-set-point event)
- 		      (current-word)))))
+ 		      (thing-at-point 'word t)))))
  	(let ((definition 
  		(dictionary-definition word dictionary-tooltip-dictionary)))
  	  (if definition 


### PR DESCRIPTION
So it can be used in code buffer as well. (current-word) only returns a
symbol, so look up fails most of the times.
