### PR TITLE
Support custom faces for definition bodies, preferably var-width.

### DIFF
--- a/dictionary.el
+++ b/dictionary.el
@@ -219,6 +219,16 @@ by the choice value:
 (if (fboundp 'defface)
     (progn
       
+      (defface dictionary-word-definition-face
+	'((((supports '(:family "DejaVu Serif")))
+	   (:family "DejaVu Serif"))
+	  (((type x))
+	   (:font "Sans Serif"))
+	  (t
+	   (:font "default")))
+	"The face that is used for displaying the definition of the word."
+	:group 'dictionary)
+
       (defface dictionary-word-entry-face
 	'((((type x))
 	   (:italic t))
@@ -780,6 +790,7 @@ This function knows about the special meaning of quotes (\")"
   (let ((start (point)))
     (insert (dictionary-decode-charset reply dictionary))
     (insert "\n\n")
+    (put-text-property start (point) 'face 'dictionary-word-definition-face)
     (let ((regexp "\\({+\\)\\([^ '\"][^}]*\\)\\(}+\\)"))
       (goto-char start)
       (while (< (point) (point-max))


### PR DESCRIPTION
Per https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=864644:

Define and use a new dictionary-word-definition-face, which defaults
to "DejaVu Serif", if that font family is supported. If that font
isn't available and the display type is "X", "Sans Serif" is
used. Otherwise, the default fonts are used.
