### PR TITLE
Removed unnecessary quote in dictionary-word-definition-face

### DIFF
--- a/dictionary.el
+++ b/dictionary.el
@@ -220,7 +220,7 @@ by the choice value:
     (progn
       
       (defface dictionary-word-definition-face
-	'((((supports '(:family "DejaVu Serif")))
+	'((((supports (:family "DejaVu Serif")))
 	   (:family "DejaVu Serif"))
 	  (((type x))
 	   (:font "Sans Serif"))


### PR DESCRIPTION
The quote before (:family ...) in line 223 is unnecessary and causes Emacs to emit the error message "invalid face reference: quote".

Tested in Emacs version 26.1 on Debian.