### PR TITLE
Fix typos in package commentary

### DIFF
--- a/dictionary.el
+++ b/dictionary.el
@@ -22,14 +22,14 @@
 
 ;;; Commentary:
 
-;; dictionary allows you to interact with dictionary servers. Use M-x
-;; customize-group dictioanry to modify all user settings.
+;; dictionary allows you to interact with dictionary servers.
+;; Use M-x customize-group dictionary to modify user settings.
 ;;
 ;; Main functions for interaction are:
 ;; dictionary        - opens a new dictionary buffer
 ;; dictionary-search - search for the definition of a word
 ;;
-;; You can find more information in the README file of the gibhub
+;; You can find more information in the README file of the GitHub
 ;; repository https://github.com/myrkr/dictionary-el
 
 ;;; Code:


### PR DESCRIPTION
This commentary is visible in the help window containing package details, and "gibhub" jumped out at me.

Thanks for a great Emacs package. I've been using it for years.