### PR TITLE
Add customizable variable to disable restoring window configuration

### DIFF
--- a/dictionary.el
+++ b/dictionary.el
@@ -185,6 +185,12 @@ by the choice value:
   :group 'dictionary
   :type 'boolean)
 
+(defcustom dictionary-restore-window-configuration
+  t
+  "Should the window configuration be restored when a dictionary buffer is killed?"
+  :group 'dictionary
+  :type 'boolean)
+
 (defcustom dictionary-description-open-delimiter
   ""
   "The delimiter to display in front of the dictionaries description"
@@ -524,7 +530,8 @@ by the choice value:
 	(let ((configuration dictionary-window-configuration)
 	      (selected-window dictionary-selected-window))
 	  (kill-buffer (current-buffer))
-	  (set-window-configuration configuration)
+	  (when dictionary-restore-window-configuration
+            (set-window-configuration configuration))
 	  (select-window selected-window)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/dictionary.el
+++ b/dictionary.el
@@ -531,8 +531,8 @@ by the choice value:
 	      (selected-window dictionary-selected-window))
 	  (kill-buffer (current-buffer))
 	  (when dictionary-restore-window-configuration
-            (set-window-configuration configuration))
-	  (select-window selected-window)))))
+            (set-window-configuration configuration)
+	    (select-window selected-window))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helpful functions


### PR DESCRIPTION
Hi there!  The way I use this package differs somewhat from the intended design I guess, but would you consider adding this option to not mess with window configurations when killing a Dictionary buffer?  Also, though I think this change would count as 'trivial', I have signed the FSF copyright assignment paperwork, which I assume would be necessary to contribute to this project given it is included in Emacs itself.  Thanks!