### PR TITLE
Add customizable var to change the buffer display function used for new buffers

### DIFF
--- a/dictionary.el
+++ b/dictionary.el
@@ -185,6 +185,12 @@ by the choice value:
   :group 'dictionary
   :type 'boolean)
 
+(defcustom dictionary-buffer-display-function
+  'switch-to-buffer-other-window
+  "Function to call to display new dictionary buffers."
+  :group 'dictionary
+  :type 'function)
+
 (defcustom dictionary-description-open-delimiter
   ""
   "The delimiter to display in front of the dictionaries description"
@@ -385,7 +391,7 @@ by the choice value:
         (window-configuration (current-window-configuration))
         (selected-window (frame-selected-window)))
     
-    (switch-to-buffer-other-window buffer)
+    (funcall dictionary-buffer-display-function buffer)
     (dictionary-mode)
     
     (make-local-variable 'dictionary-window-configuration)


### PR DESCRIPTION
Hi yet again, this is the last PR from me today I think.  This one lets you specify a custom buffer display function used when new buffers are created.  I use `pop-to-buffer-same-window` and along with the other patches, if I am opening a series a dictionary entries, they work together to provide a navigation experience similar to Dired, or eww using `o` to open links.