### PR TITLE
Put the word for which no results were found into the ‘not found’ message

### DIFF
--- a/dictionary.el
+++ b/dictionary.el
@@ -693,8 +693,7 @@ This function knows about the special meaning of quotes (\")"
 	(progn
 	  (unless nomatching
 	    (beep)
-	    (insert "Word not found, maybe you are looking "
-		    "for one of these words\n\n")
+            (insert "Word ‘" word "’ not found\n\n")
 	    (dictionary-do-matching word
 				    dictionary
 				    "."


### PR DESCRIPTION
Hi again, I guess I am making another PR today after all.  I think it would be useful to have the word that was searched for in the message text telling you there were no results.  Also, though I think this is more a matter of taste, I have removed the second part of the original sentence.  I don't think it makes sense to have it there given it shows up unconditionally, and it's possible to search for a word for which there are no results or even suggested similar words.